### PR TITLE
Add sidekiq to ror.txt

### DIFF
--- a/wordlists/vulns/ror.txt
+++ b/wordlists/vulns/ror.txt
@@ -119,3 +119,4 @@ javascripts/application.js
 javascripts/prototype.js
 stylesheets/application.css
 images/rails.png
+sidekiq


### PR DESCRIPTION
**Sidekiq** background job processing for Ruby. Often you may find it **exposed** in ROR applications by just doing `GET /sidekiq HTTP/1.1`

Impact of this is that an attacker is able to **fully control** (depending on the configuration, but usually it's full control) application queues and jobs, including **stopping and deleting queues**.

And this **leads to severe security implications**.

![image](https://user-images.githubusercontent.com/28516476/27768927-d5995e40-5f27-11e7-8902-ca60533c4c7c.png)
